### PR TITLE
Particle shapes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.8.2+build.194
 # Mod Properties
 maven_group = org.kilocraft.essentials
 archives_base_name = kilo_essentials
-mod_version = 1.9.8.2-StaySafe-20w18a
+mod_version = 1.9.9.0-StaySafe-20w18a
 
 # Dependencies
 # A set of annotations used for code inspection support and code documentation.

--- a/src/main/java/org/kilocraft/essentials/api/world/ParticleFrame.java
+++ b/src/main/java/org/kilocraft/essentials/api/world/ParticleFrame.java
@@ -16,12 +16,13 @@ public class ParticleFrame<P extends ParticleEffect> {
     private double speed;
     private int count;
     private Type type;
+    private boolean relative;
 
     public ParticleFrame(P effect,
                          boolean longDistance,
                          RelativePosition relPos,
                          double offsetX, double offsetY, double offsetZ,
-                         double speed, int count) {
+                         double speed, int count, boolean relative) {
 
         this.effect = effect;
         this.longDistance = longDistance;
@@ -32,6 +33,7 @@ public class ParticleFrame<P extends ParticleEffect> {
         this.speed = speed;
         this.count = count;
         this.type = Type.NORMAL;
+        this.relative = relative;
     }
 
     @Nullable
@@ -84,8 +86,12 @@ public class ParticleFrame<P extends ParticleEffect> {
         return effect;
     }
 
+    public boolean getRelative () {
+        return relative;
+    }
+
     @Nullable
-    public ParticleS2CPacket toPacket(Vec3d vec3d) {
+    public ParticleS2CPacket toPacket(Vec3d vec3d, float rotation) {
         Vec3d vec = relativePosition.getRelativeVector(vec3d);
 
         return new ParticleS2CPacket(

--- a/src/main/java/org/kilocraft/essentials/api/world/ParticleFrame.java
+++ b/src/main/java/org/kilocraft/essentials/api/world/ParticleFrame.java
@@ -7,6 +7,7 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.registry.Registry;
 import org.jetbrains.annotations.Nullable;
+import org.kilocraft.essentials.api.KiloEssentials;
 
 public class ParticleFrame<P extends ParticleEffect> {
     private P effect;
@@ -91,8 +92,24 @@ public class ParticleFrame<P extends ParticleEffect> {
     }
 
     @Nullable
-    public ParticleS2CPacket toPacket(Vec3d vec3d, float rotation) {
+    public ParticleS2CPacket toPacket(Vec3d vec3d, double rotation) {
         Vec3d vec = relativePosition.getRelativeVector(vec3d);
+
+        if (getRelative()) {
+            if (rotation < 0) {
+                rotation += 360;
+            }
+
+            if (rotation > 360) {
+                rotation -= 360;
+            }
+
+            rotation = Math.toRadians(rotation);
+
+            double x = relativePosition.getX() * Math.cos(rotation) - relativePosition.getZ() * Math.sin(rotation);
+            double z = relativePosition.getX() * Math.sin(rotation) + relativePosition.getZ() * Math.cos(rotation);
+            vec = new Vec3d(x + vec3d.x, vec.y, z + vec3d.z);
+        }
 
         return new ParticleS2CPacket(
                 this.effect,

--- a/src/main/java/org/kilocraft/essentials/api/world/RelativePosition.java
+++ b/src/main/java/org/kilocraft/essentials/api/world/RelativePosition.java
@@ -1,5 +1,6 @@
 package org.kilocraft.essentials.api.world;
 
+import net.minecraft.server.command.CommandSource;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 

--- a/src/main/java/org/kilocraft/essentials/api/world/RelativePosition.java
+++ b/src/main/java/org/kilocraft/essentials/api/world/RelativePosition.java
@@ -1,6 +1,5 @@
 package org.kilocraft.essentials.api.world;
 
-import net.minecraft.server.command.CommandSource;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 

--- a/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/ParticleAnimationManager.java
+++ b/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/ParticleAnimationManager.java
@@ -8,8 +8,6 @@ import net.minecraft.network.Packet;
 import net.minecraft.particle.*;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.registry.Registry;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;

--- a/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/config/BezierConfigSection.java
+++ b/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/config/BezierConfigSection.java
@@ -1,0 +1,15 @@
+package org.kilocraft.essentials.extensions.magicalparticles.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class BezierConfigSection {
+
+    @Setting("points")
+    public String points;
+
+    @Setting("controlPoints")
+    public String controlPoints;
+
+}

--- a/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/config/LineConfigSection.java
+++ b/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/config/LineConfigSection.java
@@ -1,0 +1,15 @@
+package org.kilocraft.essentials.extensions.magicalparticles.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class LineConfigSection {
+
+    @Setting("startPosition")
+    public String startPosition;
+
+    @Setting("endPosition")
+    public String endPosition;
+
+}

--- a/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/config/ParticleFrameConfigSection.java
+++ b/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/config/ParticleFrameConfigSection.java
@@ -36,12 +36,19 @@ public class ParticleFrameConfigSection {
     @Setting("speed")
     public double speed = 0.0D;
 
+    @Setting("shapeProperties")
+    private ShapeConfigSection shapeParticleSection = pos.contains("^") ? new ShapeConfigSection() : null;
+
     public Optional<BlockStateParticleEffectConfigSection> getBlockStateSection() {
         return Optional.ofNullable(blockStateSection);
     }
 
     public Optional<DustParticleEffectConfigSection> getDustParticleSection() {
         return Optional.ofNullable(dustParticleSection);
+    }
+
+    public Optional<ShapeConfigSection> getShapeSection () {
+        return Optional.ofNullable(shapeParticleSection);
     }
 
     private boolean isEqualTo(ParticleType<?> particleType) {

--- a/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/config/ShapeConfigSection.java
+++ b/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/config/ShapeConfigSection.java
@@ -1,0 +1,35 @@
+package org.kilocraft.essentials.extensions.magicalparticles.config;
+
+import net.minecraft.particle.ParticleTypes;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import java.util.Optional;
+
+@ConfigSerializable
+public class ShapeConfigSection {
+
+    @Setting("shape")
+    public String shape = "square";
+
+    @Setting("size")
+    public float size = 1;
+
+    @Setting("spacing")
+    public float spacing = 0.2f;
+
+    @Setting("lineProperties")
+    public LineConfigSection lineConfigSection  = shape.equals("line") ? new LineConfigSection() : null;
+
+    @Setting("bezierProperties")
+    public BezierConfigSection bezierConfigSection = shape.equals("bezier") ? new BezierConfigSection() : null;
+
+    public Optional<LineConfigSection> getLineConfigSection() {
+        return Optional.ofNullable(lineConfigSection);
+    }
+
+    public Optional<BezierConfigSection> getBezierConfigSection() {
+        return Optional.ofNullable(bezierConfigSection);
+    }
+
+}

--- a/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/config/ShapeConfigSection.java
+++ b/src/main/java/org/kilocraft/essentials/extensions/magicalparticles/config/ShapeConfigSection.java
@@ -1,6 +1,5 @@
 package org.kilocraft.essentials.extensions.magicalparticles.config;
 
-import net.minecraft.particle.ParticleTypes;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 


### PR DESCRIPTION
Allows for squares, circles, lines and Bezier curves to be used for particles rather than manually having to place them out.

TODO (working on it right now): Make the particles relative to the player rather than being hard coded to North/South.